### PR TITLE
fix(innovation): refine responsive layout for tablet and small screens

### DIFF
--- a/src/components/ui/LinkButton.tsx
+++ b/src/components/ui/LinkButton.tsx
@@ -20,8 +20,10 @@ export default function LinkButton({
   children,
 }: LinkButtonProps) {
   const baseClasses = cn(
-    "inline-flex items-center gap-2 rounded-md border border-primary px-4 py-2",
-    "text-sm font-medium text-primary",
+    // Layout — tighter on mobile, roomier on tablet+.
+    "inline-flex items-center justify-center gap-1.5 rounded-md border border-primary",
+    "px-3 py-1.5 text-xs sm:gap-2 sm:px-4 sm:py-2 sm:text-sm",
+    "font-medium text-primary",
     "transition-colors hover:bg-primary hover:text-white",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
     className,

--- a/src/features/innovation/InnovationHub.tsx
+++ b/src/features/innovation/InnovationHub.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from "react";
 import useInnovationTabs from "@/hooks/useInnovationTabs";
 import { INNOVATION_ITEMS } from "@/data/innovation";
 import InnovationTabList from "./InnovationTabList";
@@ -6,22 +7,52 @@ import ProjectImage from "./ProjectImage";
 import ProjectActions from "./ProjectActions";
 
 /**
+ * Auto-advance interval for the tab carousel.
+ * 6s is a sweet spot — long enough to read a short paragraph,
+ * short enough to keep the section feeling alive.
+ */
+const AUTO_ADVANCE_MS = 6000;
+
+/**
  * "Innovation Hub" section.
  *
- * Mobile / tablet (< lg):
+ * Mobile / tablet (< xl):
  *   [ tabs (horizontal scroll)            ]
- *   [ title + desc      | image           ]
+ *   [ title + desc (3/5) | image (2/5)    ]
  *   [ CTAs (full width)                   ]
  *
- * Desktop (>= lg):
- *   [ tabs | image | title + desc + CTAs ]
+ * Desktop (>= xl):
+ *   [ tabs | image | title + desc + CTAs  ]
  */
 export default function InnovationHub() {
   const { active, activeId, setActiveId } = useInnovationTabs(INNOVATION_ITEMS);
+  const [isPaused, setIsPaused] = useState(false);
+
+  // Advance to the next item, wrapping at the end.
+  const next = useCallback(() => {
+    const i = INNOVATION_ITEMS.findIndex((item) => item.id === activeId);
+    const nextItem = INNOVATION_ITEMS[(i + 1) % INNOVATION_ITEMS.length];
+    setActiveId(nextItem.id);
+  }, [activeId, setActiveId]);
+
+  // Auto-advance. Resets whenever `activeId` changes (user click or auto)
+  // so manual selection always gets a full interval before the next swap.
+  useEffect(() => {
+    if (isPaused) return;
+    const id = setInterval(next, AUTO_ADVANCE_MS);
+    return () => clearInterval(id);
+  }, [isPaused, next]);
 
   return (
-    <section aria-labelledby="innovation-hub-heading" className="bg-bg">
-      <div className="mx-auto w-full max-w-6xl px-4 py-16 sm:py-20 lg:px-8">
+    <section
+      aria-labelledby="innovation-hub-heading"
+      className="bg-bg"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocus={() => setIsPaused(true)}
+      onBlur={() => setIsPaused(false)}
+    >
+      <div className="mx-auto w-full max-w-6xl px-4 py-16 sm:py-20 xl:px-8">
         {/* ── HEADER ──────────────────────────────────────────────── */}
         <header className="mb-10 text-center">
           <h2
@@ -36,17 +67,18 @@ export default function InnovationHub() {
         </header>
 
         {/* ── BODY ────────────────────────────────────────────────── */}
-        <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[200px_minmax(0,360px)_1fr] lg:gap-12">
-          {/* Tabs: full-width row on mobile, left column on desktop. */}
+        {/* Below xl: cap at a comfortable reading width and center.
+            xl+: release to the full 3-column grid. */}
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 xl:max-w-none xl:grid xl:grid-cols-[200px_minmax(0,360px)_1fr] xl:gap-12">
+          {/* Tabs: full-width row below xl, left column on xl+. */}
           <InnovationTabList
             items={INNOVATION_ITEMS}
             activeId={activeId}
             onSelect={setActiveId}
           />
 
-          {/* MOBILE / TABLET: text takes 3/5, image takes 2/5.
-              Hidden on lg — desktop renders the parts in dedicated columns below. */}
-          <div className="grid grid-cols-5 items-center gap-4 lg:hidden">
+          {/* MOBILE / TABLET: text 3/5, image 2/5. */}
+          <div className="grid grid-cols-5 items-center gap-4 xl:hidden">
             <ProjectInfo item={active} className="col-span-3 min-w-0" />
             <ProjectImage
               item={active}
@@ -54,17 +86,17 @@ export default function InnovationHub() {
             />
           </div>
 
-          {/* MOBILE / TABLET: CTAs full width below the row above. */}
-          <ProjectActions item={active} className="lg:hidden" />
+          {/* MOBILE / TABLET: CTAs full width below. */}
+          <ProjectActions item={active} className="xl:hidden" />
 
-          {/* DESKTOP: middle column — the illustration. */}
+          {/* DESKTOP: middle column — illustration. */}
           <ProjectImage
             item={active}
-            className="hidden h-full max-h-72 lg:flex"
+            className="hidden h-full max-h-72 xl:flex"
           />
 
           {/* DESKTOP: right column — info + CTAs stacked. */}
-          <div className="hidden flex-col gap-4 lg:flex">
+          <div className="hidden flex-col gap-4 xl:flex">
             <ProjectInfo item={active} />
             <ProjectActions item={active} />
           </div>

--- a/src/features/innovation/InnovationTab.tsx
+++ b/src/features/innovation/InnovationTab.tsx
@@ -7,12 +7,6 @@ interface InnovationTabProps {
   onSelect: (id: string) => void;
 }
 
-/**
- * One row in the Innovation Hub's tab list.
- *
- * Visual treatment: a thin divider line (bottom on mobile, left on
- * desktop) that changes color when active. No background fill.
- */
 export default function InnovationTab({
   item,
   isActive,
@@ -29,16 +23,12 @@ export default function InnovationTab({
       tabIndex={isActive ? 0 : -1}
       onClick={() => onSelect(id)}
       className={cn(
-        // Layout
         "flex shrink-0 items-center gap-2 whitespace-nowrap text-left text-sm transition-colors",
-        // Mobile: bottom border, horizontal padding. Desktop: left border, vertical padding.
-        "border-b-2 px-3 py-2 md:w-full md:border-b-0 md:border-l-2 md:px-4 md:py-3",
-        // Focus ring
+        "border-b-2 px-3 py-2 xl:w-full xl:border-b-0 xl:border-l-2 xl:px-4 xl:py-3",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-        // Active vs inactive
-        isActive
-          ? "border-primary font-semibold text-primary"
-          : "border-slate-200 text-slate-400 hover:border-slate-300 hover:text-slate-600",
+        isActive ?
+          "border-primary font-semibold text-primary"
+        : "border-slate-200 text-slate-400 hover:border-slate-300 hover:text-slate-600",
       )}
     >
       <Icon className="h-4 w-4 shrink-0" aria-hidden />

--- a/src/features/innovation/InnovationTabList.tsx
+++ b/src/features/innovation/InnovationTabList.tsx
@@ -7,11 +7,6 @@ interface InnovationTabListProps {
   onSelect: (id: string) => void;
 }
 
-/**
- * Left-side (desktop) / top (mobile) tab list. On mobile it scrolls
- * horizontally with a thin scrollbar; a soft fade on the right edge
- * hints at off-screen content.
- */
 export default function InnovationTabList({
   items,
   activeId,
@@ -23,7 +18,7 @@ export default function InnovationTabList({
         role="tablist"
         aria-label="Innovation Hub projects"
         aria-orientation="vertical"
-        className="scrollbar-thin flex gap-1 overflow-x-auto md:flex-col md:gap-0 md:overflow-visible"
+        className="scrollbar-thin flex gap-1 overflow-x-auto xl:flex-col xl:gap-0 xl:overflow-visible"
       >
         {items.map((item) => (
           <InnovationTab
@@ -35,11 +30,9 @@ export default function InnovationTabList({
         ))}
       </div>
 
-      {/* Mobile-only fade hint that there's more content to the right.
-          Matches the section background (bg-bg). */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-bg to-transparent md:hidden"
+        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-bg to-transparent xl:hidden"
       />
     </div>
   );

--- a/src/features/innovation/ProjectInfo.tsx
+++ b/src/features/innovation/ProjectInfo.tsx
@@ -6,10 +6,6 @@ interface ProjectInfoProps {
   className?: string;
 }
 
-/**
- * Title + description block for the active Innovation Hub project.
- * Layout-agnostic — parent decides where it sits.
- */
 export default function ProjectInfo({ item, className }: ProjectInfoProps) {
   const { id, title, description } = item;
   return (


### PR DESCRIPTION
- Push desktop layout breakpoint from md to xl so tablets keep the mobile-style flow
- Constrain body to max-w-2xl and center below xl for balanced reading
- Tighten LinkButton padding/text on mobile so all CTAs fit one row
- Auto-advance tabs every 6s, pause on hover/focus