### PR TITLE
feat(contact): add Get in Touch page with form + channel cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-hook-form": "^7.78.0",
         "react-router-dom": "^7.16.0",
         "tailwind-merge": "^3.6.0"
       },
@@ -2733,6 +2734,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.78.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz",
+      "integrity": "sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-hook-form": "^7.78.0",
     "react-router-dom": "^7.16.0",
     "tailwind-merge": "^3.6.0"
   },

--- a/src/data/contact.ts
+++ b/src/data/contact.ts
@@ -1,0 +1,29 @@
+import { MessageCircle, Wrench, Users } from "lucide-react";
+import type { ContactChannel } from "@/types/contact";
+
+export const CONTACT_EMAIL = "hello@buildfornepal.org";
+
+export const CONTACT_CHANNELS: ContactChannel[] = [
+  {
+    id: "general-inquiries",
+    title: "General Inquiries",
+    description: "For questions about our mission and general community info.",
+    icon: MessageCircle,
+    email: CONTACT_EMAIL,
+  },
+  {
+    id: "product-support",
+    title: "Product Support",
+    description: "Facing issues with our apps? Our dev team is here to help.",
+    icon: Wrench,
+    email: CONTACT_EMAIL,
+  },
+  {
+    id: "collaborate",
+    title: "Collaborate with Us",
+    description:
+      "Open-source enthusiast? Let's build something great together.",
+    icon: Users,
+    email: CONTACT_EMAIL,
+  },
+];

--- a/src/features/getInTouch/ContactChannelCard.tsx
+++ b/src/features/getInTouch/ContactChannelCard.tsx
@@ -1,0 +1,35 @@
+import type { ContactChannel } from "@/types/contact";
+
+interface ContactChannelCardProps {
+  channel: ContactChannel;
+}
+
+export default function ContactChannelCard({
+  channel,
+}: ContactChannelCardProps) {
+  const { title, description, icon: Icon, email } = channel;
+
+  return (
+    <article className="flex gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm sm:p-6">
+      <div
+        className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-white"
+        aria-hidden="true"
+      >
+        <Icon className="h-5 w-5" />
+      </div>
+
+      <div className="min-w-0">
+        <h3 className="text-base font-bold text-dark sm:text-lg">{title}</h3>
+
+        <p className="mt-1 text-sm text-muted">{description}</p>
+
+        <a
+          href={`mailto:${email}`}
+          className="mt-3 inline-block break-all text-sm font-semibold text-primary transition-colors hover:text-accent-hover"
+        >
+          {email}
+        </a>
+      </div>
+    </article>
+  );
+}

--- a/src/features/getInTouch/ContactForm.tsx
+++ b/src/features/getInTouch/ContactForm.tsx
@@ -1,0 +1,220 @@
+import { CheckCircle2, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import type { ContactFormPayload, ContactSubject } from "@/types/contact";
+
+const SUBJECT_OPTIONS: { value: ContactSubject; label: string }[] = [
+  { value: "general", label: "General Inquiry" },
+  { value: "product-support", label: "Product Support" },
+  { value: "collaboration", label: "Collaboration" },
+  { value: "other", label: "Other" },
+];
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type FormState = Omit<ContactFormPayload, "subject"> & {
+  subject: ContactSubject | "";
+};
+
+export default function ContactForm() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors, isSubmitting },
+  } = useForm<FormState>({
+    defaultValues: {
+      fullName: "",
+      email: "",
+      subject: "",
+      message: "",
+    },
+  });
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const subjectValue = useWatch({ control, name: "subject" });
+
+  const onSubmit = (data: FormState) => {
+    if (!data.subject) return;
+
+    const payload: ContactFormPayload = { ...data, subject: data.subject };
+
+    // TODO(backend): swap console.log for a real submit handler
+    console.log("Contact form submitted:", payload);
+
+    setIsSubmitted(true);
+    reset();
+    // No auto-dismiss — user clicks "Send another message" to come back.
+    // Industry standard: don't yank confirmation away before the user reads it.
+  };
+
+  // Lets the user go back to the form after seeing the success state.
+  const handleSendAnother = () => setIsSubmitted(false);
+
+  // SUCCESS STATE — replaces the form entirely once a submission lands.
+  // Same card shell as the form so the layout doesn't jump.
+  if (isSubmitted) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex min-h-[400px] flex-col items-center justify-center rounded-2xl bg-white p-8 text-center shadow-md sm:p-12"
+      >
+        {/* Soft teal halo behind the icon for a "celebratory" hit without being noisy. */}
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+          <CheckCircle2 className="h-10 w-10 text-primary" aria-hidden="true" />
+        </div>
+
+        <h3 className="mt-6 text-2xl font-bold text-dark sm:text-3xl">
+          Message sent
+        </h3>
+
+        <p className="mt-3 max-w-sm text-sm text-muted sm:text-base">
+          Thanks for reaching out. We&apos;ll get back to you soon.
+        </p>
+
+        <button
+          type="button"
+          onClick={handleSendAnother}
+          className="mt-8 inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-6 text-sm font-semibold text-dark transition-colors hover:border-primary hover:text-primary"
+        >
+          Send another message
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-white p-6 shadow-md sm:p-8">
+      <h3 className="text-2xl font-bold text-primary sm:text-3xl">
+        Drop us a Line
+      </h3>
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+        className="mt-6 space-y-5"
+      >
+        {/* Name + Email row. */}
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <Field
+            label="Full Name"
+            htmlFor="fullName"
+            error={errors.fullName?.message}
+          >
+            <input
+              id="fullName"
+              type="text"
+              placeholder="John Doe"
+              className="input-base"
+              {...register("fullName", {
+                required: "Please tell us your name",
+                minLength: { value: 2, message: "Name is too short" },
+              })}
+            />
+          </Field>
+
+          <Field
+            label="Email Address"
+            htmlFor="email"
+            error={errors.email?.message}
+          >
+            <input
+              id="email"
+              type="email"
+              placeholder="john@example.com"
+              className="input-base"
+              {...register("email", {
+                required: "Email is required",
+                pattern: {
+                  value: EMAIL_PATTERN,
+                  message: "Please enter a valid email address",
+                },
+              })}
+            />
+          </Field>
+        </div>
+
+        <Field
+          label="Subject"
+          htmlFor="subject"
+          error={errors.subject?.message}
+        >
+          <select
+            id="subject"
+            className={`input-base ${subjectValue === "" ? "text-gray-400" : "text-dark"}`}
+            {...register("subject", { required: "Please choose a subject" })}
+          >
+            <option value="" disabled hidden>
+              General Inquiry
+            </option>
+            {SUBJECT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value} className="text-dark">
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field
+          label="Message"
+          htmlFor="message"
+          error={errors.message?.message}
+        >
+          <textarea
+            id="message"
+            rows={5}
+            placeholder="How can we help you?"
+            className="input-base resize-y"
+            {...register("message", {
+              required: "Don't forget your message",
+              minLength: { value: 10, message: "Message is a bit too short" },
+            })}
+          />
+        </Field>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-6 text-sm font-semibold text-white transition-all hover:bg-accent-hover active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? "Sending…" : "Send Message"}
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </form>
+    </div>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+function Field({ label, htmlFor, error, children }: FieldProps) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1.5 block text-sm font-medium text-dark"
+      >
+        {label}
+      </label>
+      {children}
+
+      {error && (
+        <p
+          role="alert"
+          aria-live="polite"
+          className="mt-1.5 text-xs text-red-600"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/getInTouch/GetInTouch.tsx
+++ b/src/features/getInTouch/GetInTouch.tsx
@@ -1,0 +1,42 @@
+import { CONTACT_CHANNELS } from "@/data/contact";
+import ContactChannelCard from "./ContactChannelCard";
+import ContactForm from "./ContactForm";
+
+export default function GetInTouch() {
+  return (
+    <section aria-labelledby="get-in-touch-heading" className="bg-bg">
+      {/* TEAL BANNER — pt-20 pb-40 matches the Mission section pattern.
+          The big pb creates room for the content card to "break" the band. */}
+      <div className="bg-primary px-6 pt-20 pb-40 text-center">
+        <h2
+          id="get-in-touch-heading"
+          className="text-[32px] font-bold text-white sm:text-[40px] lg:text-[52px]"
+        >
+          Get in Touch
+        </h2>
+        <p className="mx-auto mt-3 max-w-2xl text-base text-white/90">
+          Have a question about our products or want to collaborate on a project
+          for Nepal? We&apos;re here to help and listen.
+        </p>
+      </div>
+
+      {/* CONTENT — overlap pattern from Mission: page-wrapper + -mt-10
+          pulls content up to break into the teal band above. */}
+      <div className="page-wrapper -mt-10 pb-16 sm:pb-20">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3 lg:gap-8">
+          {/* Form spans 2 cols at lg so it gets the most space. */}
+          <div className="lg:col-span-2">
+            <ContactForm />
+          </div>
+
+          {/* Right column — stacked channel cards. */}
+          <div className="flex flex-col gap-4 sm:gap-6">
+            {CONTACT_CHANNELS.map((channel) => (
+              <ContactChannelCard key={channel.id} channel={channel} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,27 @@ body {
   @apply text-primary;
 }
 
+/* Shared input styling — used by ContactForm <input>, <select>, <textarea>.
+   Light gray fill matches the design, teal focus ring matches the brand.
+   Stronger border (gray-300) so it stays visible against the gray-50 fill. */
+.input-base {
+  @apply w-full rounded-lg border border-gray-300 bg-gray-50 px-4 py-3 text-sm text-dark
+         placeholder:text-gray-400
+         focus:border-primary focus:bg-white focus:outline-none focus:ring-2 focus:ring-primary/20
+         transition-colors duration-150;
+}
+
+/* Select-specific overrides.
+   - appearance-none kills the default OS arrow so we can render our own
+   - bg-[url] adds a custom chevron SVG, positioned right
+   - pr-10 reserves space so the selected text never collides with the chevron */
+select.input-base {
+  @apply appearance-none bg-no-repeat pr-10;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23666666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-position: right 1rem center;
+  background-size: 1rem;
+}
+
 @layer utilities {
   .page-wrapper {
     @apply mx-auto w-full max-w-7xl px-4 lg:px-8;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,9 @@
+import GetInTouch from "@/features/getInTouch/GetInTouch";
+
+export default function Contact() {
+  return (
+    <main>
+      <GetInTouch />
+    </main>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import RootLayout from "@/components/layout/RootLayout";
 import Home from "@/pages/Home";
 import About from "@/pages/About";
+import Contact from "@/pages/Contact";
 import NotFound from "@/pages/NotFound";
 import { createBrowserRouter } from "react-router-dom";
 
@@ -11,6 +12,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: "about", element: <About /> },
+      { path: "contact", element: <Contact /> },
       { path: "*", element: <NotFound /> },
     ],
   },

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -1,0 +1,27 @@
+import type { LucideIcon } from "lucide-react";
+
+// One "channel" you can reach us through — one card on the right of the form.
+export interface ContactChannel {
+  id: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  email: string;
+}
+
+// Allowed values for the form's <select> "Subject" dropdown.
+// Literal union = TS catches typos at compile time, zero runtime cost.
+export type ContactSubject =
+  | "general"
+  | "product-support"
+  | "collaboration"
+  | "other";
+
+// What the form hands off when submitted.
+// Shared so the future submit handler (API, Formspree, etc.) types cleanly.
+export interface ContactFormPayload {
+  fullName: string;
+  email: string;
+  subject: ContactSubject;
+  message: string;
+}


### PR DESCRIPTION
Introduce a new /contact route featuring a "Get in Touch" section: a teal banner overlapping a white form card on the left and three contact channel cards (General Inquiries, Product Support, Collaborate) on the right. The layout mirrors the Mission section's banner + overlap pattern for visual consistency.

- Add ContactChannel + ContactFormPayload types and CONTACT_CHANNELS data with shared CONTACT_EMAIL constant
- Add ContactChannelCard, ContactForm, and GetInTouch section under features/getInTouch/
- Build ContactForm with react-hook-form: inline validation for required + email pattern, Compiler-safe useWatch for placeholder styling, internal FormState type narrowed to ContactFormPayload on submit, accessible error messages with aria-live
- Add .input-base utility and select-specific chevron styling to index.css for consistent form controls across the site
- Register /contact route and Contact page mounting GetInTouch