### PR TITLE
fix(hero): align hero content with navbar via page-wrapper

### DIFF
--- a/src/features/hero/HeroSlide.tsx
+++ b/src/features/hero/HeroSlide.tsx
@@ -35,7 +35,7 @@ export default function HeroSlide({ slide, onPrev, onNext }: HeroSlideProps) {
 
   return (
     <div
-      className="relative flex h-hero w-full items-center justify-center overflow-hidden bg-primary bg-cover bg-center sm:h-auto sm:min-h-hero sm:justify-start sm:px-10 lg:px-20"
+      className="relative flex h-hero w-full items-center justify-center overflow-hidden bg-primary bg-cover bg-center sm:h-auto sm:min-h-hero sm:justify-start"
       style={
         hasPhoto ?
           { backgroundImage: `url('${background!.image}')` }
@@ -48,27 +48,29 @@ export default function HeroSlide({ slide, onPrev, onNext }: HeroSlideProps) {
         <div className="absolute inset-0 hidden bg-linear-to-r from-primary/90 via-primary/75 to-primary/50 sm:block" />
       )}
 
-      {/* ── TEXT ─────────────────────────────────────────────────────── */}
-      <div className="relative z-20 flex flex-col items-center px-6 pb-[4dvh] text-center sm:w-1/2 sm:max-w-[52%] sm:items-start sm:pb-0 sm:text-left">
-        <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl xl:text-6xl">
-          {heading}
-        </h1>
-        <p className="mt-3 text-sm leading-relaxed text-white/85 sm:mt-5 sm:text-base lg:mt-6 lg:text-lg">
-          {subtitle}
-        </p>
+      {/* ── TEXT (now inside page-wrapper so it lines up with the navbar) ── */}
+      <div className="page-wrapper relative z-20">
+        <div className="flex flex-col items-center pb-[4dvh] text-center sm:max-w-[52%] sm:items-start sm:pb-0 sm:text-left">
+          <h1 className="text-3xl font-bold leading-tight text-white sm:text-4xl lg:text-5xl xl:text-6xl">
+            {heading}
+          </h1>
+          <p className="mt-3 text-sm leading-relaxed text-white/85 sm:mt-5 sm:text-base lg:mt-6 lg:text-lg">
+            {subtitle}
+          </p>
 
-        <div className="mt-5 flex items-center gap-1 ">
-          <SlideArrowButton direction="prev" onClick={onPrev} />
-          <SlideArrowButton direction="next" onClick={onNext} />
+          <div className="mt-5 flex items-center gap-1">
+            <SlideArrowButton direction="prev" onClick={onPrev} />
+            <SlideArrowButton direction="next" onClick={onNext} />
+          </div>
+
+          <Link
+            to={ctaHref}
+            className="mt-4 inline-flex h-11 items-center gap-2 rounded-full border-2 border-white bg-white px-5 text-xs font-semibold text-primary transition-all duration-200 hover:bg-transparent hover:text-white sm:mt-5 sm:px-8 sm:text-base"
+          >
+            {ctaLabel}
+            <ChevronRight size={16} aria-hidden />
+          </Link>
         </div>
-
-        <Link
-          to={ctaHref}
-          className="mt-4 inline-flex items-center gap-2 rounded-full border-2 border-white bg-white px-5 py-2.5 text-xs font-semibold text-primary transition-all duration-200 hover:bg-transparent hover:text-white sm:mt-5 sm:px-8 sm:py-3 sm:text-base"
-        >
-          {ctaLabel}
-          <ChevronRight size={16} aria-hidden />
-        </Link>
       </div>
 
       {/* ── ILLUSTRATION ─────────────────────────────────────────────── */}


### PR DESCRIPTION
Replace ad-hoc sm:px-10/lg:px-20 padding on HeroSlide with the shared .page-wrapper utility so the headline lines up with the navbar logo at all breakpoints. Bump CTA height to h-11 to meet the 44px tap target.